### PR TITLE
Add archive notice and link to observiq/terraform-provider-bindplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,35 @@
 BindPlane Enterprise Terraform Provider
 ==========================
 
-[![CI](https://github.com/observIQ/terraform-provider-bindplane-enterprise/actions/workflows/ci.yml/badge.svg)](https://github.com/observIQ/terraform-provider-bindplane-enterprise/actions/workflows/ci.yml)
+### Archived
 
-Terraform provider for observIQ's agent management platform, [BindPlane OP](https://github.com/observIQ/bindplane-op).
+The enterprise features of this provider have been ported to [observIQ/terraform-provider-bindplane](https://github.com/observIQ/terraform-provider-bindplane).
 
-## Documentation
+### Migration
 
-The enterprise provider extends the [bindplane provider](https://registry.terraform.io/providers/observIQ/bindplane/latest/docs). Resource configuration is the same. See the [bindplane provider documentation](https://registry.terraform.io/providers/observIQ/bindplane/latest/docs) site for information on configuration and usage.
+To migrate from `observiq/bindplane-enterprise` to `observiq/bindplane` by updating
+your `required_providers` configuration.
 
-# Community
+**Before**
 
-BindPlane Enterprise Terraform Provider is an open source project. If you'd like to contribute, take a look at our [contribution guidelines](/docs/CONTRIBUTING.md). We look forward to building with you.
+```tf
+terraform {
+  required_providers {
+    bindplane = {
+      source = "observiq/bindplane-enterprise"
+    }
+  }
+}
+```
 
-## Code of Conduct
+**After**
 
-BindPlane Enterprise Terraform Provider follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). Please report violations of the Code of Conduct to any or all [maintainers](/docs/MAINTAINERS.md).
-
-# Other questions?
-
-Send us an [email](mailto:support@observiq.com), or open an issue with your question. We'd love to hear from you!
+```
+terraform {
+  required_providers {
+    bindplane = {
+      source = "observiq/bindplane"
+    }
+  }
+}
+```


### PR DESCRIPTION
<!--Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

## Description of Changes

`observiq/terraform-provider-bindplane` is fully featured and this provider is no longer needed for BindPlane OP Enterprise and Cloud users.

Merge after https://github.com/observIQ/terraform-provider-bindplane/pull/35

## **Please check that the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CI passes
